### PR TITLE
Remove deprecated syntax

### DIFF
--- a/benchmarks/arK/arK.stan
+++ b/benchmarks/arK/arK.stan
@@ -1,27 +1,26 @@
 data {
   int<lower=0> K;
   int<lower=0> T;
-  real y[T];
+  array[T] real y;
 }
-
 parameters {
   real alpha;
-  real beta[K];
+  array[K] real beta;
   real<lower=0> sigma;
 }
-
 model {
   alpha ~ normal(0, 10);
   beta ~ normal(0, 10);
   sigma ~ cauchy(0, 2.5);
   
-  for (t in (K+1):T) {
+  for (t in (K + 1) : T) {
     real mu;
     mu = alpha;
     
-    for (k in 1:K)
+    for (k in 1 : K) 
       mu = mu + beta[k] * y[t - k];
     
     y[t] ~ normal(mu, sigma);
   }
 }
+

--- a/benchmarks/arma/arma.stan
+++ b/benchmarks/arma/arma.stan
@@ -2,18 +2,16 @@
 
 data {
   int<lower=1> T; // number of observations
-  real y[T];      // observed outputs
+  array[T] real y; // observed outputs
 }
-
 parameters {
-  real mu;             // mean coefficient
-  real phi;            // autoregression coefficient
-  real theta;          // moving average coefficient
+  real mu; // mean coefficient
+  real phi; // autoregression coefficient
+  real theta; // moving average coefficient
   real<lower=0> sigma; // noise scale
 }
-
 model {
-  vector[T] nu;  // prediction for time t
+  vector[T] nu; // prediction for time t
   vector[T] err; // error for time t
   
   mu ~ normal(0, 10);
@@ -23,10 +21,11 @@ model {
   
   nu[1] = mu + phi * mu; // assume err[0] == 0
   err[1] = y[1] - nu[1];
-  for (t in 2:T) {
+  for (t in 2 : T) {
     nu[t] = mu + phi * y[t - 1] + theta * err[t - 1];
     err[t] = y[t] - nu[t];
   }
   
   err ~ normal(0, sigma);
 }
+

--- a/benchmarks/eight_schools/eight_schools.stan
+++ b/benchmarks/eight_schools/eight_schools.stan
@@ -1,24 +1,22 @@
 data {
   int<lower=0> J;
-  real y[J];
-  real<lower=0> sigma[J];
+  array[J] real y;
+  array[J] real<lower=0> sigma;
 }
-
 parameters {
   real mu;
   real<lower=0> tau;
-  real theta_tilde[J];
+  array[J] real theta_tilde;
 }
-
 transformed parameters {
-  real theta[J];
-  for (j in 1:J)
+  array[J] real theta;
+  for (j in 1 : J) 
     theta[j] = mu + tau * theta_tilde[j];
 }
-
 model {
   mu ~ normal(0, 5);
   tau ~ cauchy(0, 5);
   theta_tilde ~ normal(0, 1);
   y ~ normal(theta, sigma);
 }
+

--- a/benchmarks/garch/garch.stan
+++ b/benchmarks/garch/garch.stan
@@ -1,23 +1,21 @@
 data {
-  int<lower=0> T; 
-  real y[T];
-  real<lower=0> sigma1; 
+  int<lower=0> T;
+  array[T] real y;
+  real<lower=0> sigma1;
 }
-
 parameters {
-  real mu; 
-  real<lower=0> alpha0;          
+  real mu;
+  real<lower=0> alpha0;
   real<lower=0, upper=1> alpha1;
-  real<lower=0, upper=(1-alpha1)> beta1; 
+  real<lower=0, upper=(1 - alpha1)> beta1;
 }
-
 model {
-  real sigma[T];
+  array[T] real sigma;
   sigma[1] = sigma1;
-  for (t in 2:T)
-    sigma[t] = sqrt(  alpha0
-                    + alpha1 * square(y[t - 1] - mu)
+  for (t in 2 : T) 
+    sigma[t] = sqrt(alpha0 + alpha1 * square(y[t - 1] - mu)
                     + beta1 * square(sigma[t - 1]));
-
+  
   y ~ normal(mu, sigma);
 }
+

--- a/benchmarks/gp_pois_regr/gp_pois_regr.stan
+++ b/benchmarks/gp_pois_regr/gp_pois_regr.stan
@@ -1,29 +1,27 @@
 data {
   int<lower=1> N;
-  real x[N];
-  int k[N];
+  array[N] real x;
+  array[N] int k;
 }
-
 parameters {
   real<lower=0> rho;
   real<lower=0> alpha;
   vector[N] f_tilde;
 }
-
 transformed parameters {
   vector[N] f;
   {
-    matrix[N, N] cov =   cov_exp_quad(x, alpha, rho)
+    matrix[N, N] cov = gp_exp_quad_cov(x, alpha, rho)
                        + diag_matrix(rep_vector(1e-10, N));
     matrix[N, N] L_cov = cholesky_decompose(cov);
     f = L_cov * f_tilde;
   }
 }
-
 model {
   rho ~ gamma(25, 4);
   alpha ~ normal(0, 2);
   f_tilde ~ normal(0, 1);
-
+  
   k ~ poisson_log(f);
 }
+

--- a/benchmarks/gp_regr/gen_gp_data.stan
+++ b/benchmarks/gp_regr/gen_gp_data.stan
@@ -3,24 +3,27 @@ transformed data {
   real alpha = 3;
   real sigma = 2;
 }
-
-parameters {}
-model {}
-
+parameters {
+  
+}
+model {
+  
+}
 generated quantities {
   int<lower=1> N = 11;
-  real x[11] = {-10, -8, -6, -4, -2, 0.0, 2, 4, 6, 8, 10};
+  array[11] real x = {-10, -8, -6, -4, -2, 0.0, 2, 4, 6, 8, 10};
   vector[11] y;
-  int k[11];
+  array[11] int k;
   {
-    matrix[N, N] cov =   cov_exp_quad(x, alpha, rho)
+    matrix[N, N] cov = gp_exp_quad_cov(x, alpha, rho)
                        + diag_matrix(rep_vector(1e-10, N));
     matrix[N, N] L_cov = cholesky_decompose(cov);
     vector[N] f = multi_normal_cholesky_rng(rep_vector(0, N), L_cov);
-
-    for (n in 1:N) {
+    
+    for (n in 1 : N) {
       y[n] = normal_rng(f[n], sigma);
       k[n] = poisson_rng(exp(f[n]));
     }
   }
 }
+

--- a/benchmarks/gp_regr/gp_regr.stan
+++ b/benchmarks/gp_regr/gp_regr.stan
@@ -1,23 +1,22 @@
 data {
   int<lower=1> N;
-  real x[N];
+  array[N] real x;
   vector[N] y;
 }
-
 parameters {
   real<lower=0> rho;
   real<lower=0> alpha;
   real<lower=0> sigma;
 }
-
 model {
-  matrix[N, N] cov =   cov_exp_quad(x, alpha, rho)
+  matrix[N, N] cov = gp_exp_quad_cov(x, alpha, rho)
                      + diag_matrix(rep_vector(sigma, N));
   matrix[N, N] L_cov = cholesky_decompose(cov);
-
+  
   rho ~ gamma(25, 4);
   alpha ~ normal(0, 2);
   sigma ~ normal(0, 1);
-
+  
   y ~ multi_normal_cholesky(rep_vector(0, N), L_cov);
 }
+

--- a/benchmarks/irt_2pl/irt_2pl.stan
+++ b/benchmarks/irt_2pl/irt_2pl.stan
@@ -1,32 +1,31 @@
 data {
   int<lower=0> I;
   int<lower=0> J;
-  int<lower=0, upper=1> y[I, J];
+  array[I, J] int<lower=0, upper=1> y;
 }
-
 parameters {
   real<lower=0> sigma_theta;
   vector[J] theta;
-
+  
   real<lower=0> sigma_a;
   vector<lower=0>[I] a;
-
+  
   real mu_b;
   real<lower=0> sigma_b;
   vector[I] b;
 }
-
 model {
   sigma_theta ~ cauchy(0, 2);
-  theta ~ normal(0, sigma_theta); 
-
+  theta ~ normal(0, sigma_theta);
+  
   sigma_a ~ cauchy(0, 2);
   a ~ lognormal(0, sigma_a);
-
+  
   mu_b ~ normal(0, 5);
   sigma_b ~ cauchy(0, 2);
   b ~ normal(mu_b, sigma_b);
-
-  for (i in 1:I)
+  
+  for (i in 1 : I) 
     y[i] ~ bernoulli_logit(a[i] * (theta - b[i]));
 }
+

--- a/benchmarks/low_dim_gauss_mix/low_dim_gauss_mix.stan
+++ b/benchmarks/low_dim_gauss_mix/low_dim_gauss_mix.stan
@@ -1,20 +1,18 @@
 data {
- int<lower = 0> N;
- vector[N] y;
+  int<lower=0> N;
+  vector[N] y;
 }
-
 parameters {
   ordered[2] mu;
-  real<lower=0> sigma[2];
+  array[2] real<lower=0> sigma;
   real<lower=0, upper=1> theta;
 }
-
 model {
- sigma ~ normal(0, 2);
- mu ~ normal(0, 2);
- theta ~ beta(5, 5);
- for (n in 1:N)
-   target += log_mix(theta,
-                     normal_lpdf(y[n] | mu[1], sigma[1]),
-                     normal_lpdf(y[n] | mu[2], sigma[2]));
+  sigma ~ normal(0, 2);
+  mu ~ normal(0, 2);
+  theta ~ beta(5, 5);
+  for (n in 1 : N) 
+    target += log_mix(theta, normal_lpdf(y[n] | mu[1], sigma[1]),
+                      normal_lpdf(y[n] | mu[2], sigma[2]));
 }
+

--- a/benchmarks/low_dim_gauss_mix_collapse/low_dim_gauss_mix_collapse.stan
+++ b/benchmarks/low_dim_gauss_mix_collapse/low_dim_gauss_mix_collapse.stan
@@ -1,20 +1,18 @@
 data {
- int<lower = 0> N;
- vector[N] y;
+  int<lower=0> N;
+  vector[N] y;
 }
-
 parameters {
   vector[2] mu;
-  real<lower=0> sigma[2];
+  array[2] real<lower=0> sigma;
   real<lower=0, upper=1> theta;
 }
-
 model {
- sigma ~ normal(0, 2);
- mu ~ normal(0, 2);
- theta ~ beta(5, 5);
- for (n in 1:N)
-   target += log_mix(theta,
-                     normal_lpdf(y[n] | mu[1], sigma[1]),
-                     normal_lpdf(y[n] | mu[2], sigma[2]));
+  sigma ~ normal(0, 2);
+  mu ~ normal(0, 2);
+  theta ~ beta(5, 5);
+  for (n in 1 : N) 
+    target += log_mix(theta, normal_lpdf(y[n] | mu[1], sigma[1]),
+                      normal_lpdf(y[n] | mu[2], sigma[2]));
 }
+

--- a/benchmarks/pkpd/one_comp_mm_elim_abs.stan
+++ b/benchmarks/pkpd/one_comp_mm_elim_abs.stan
@@ -1,10 +1,8 @@
 functions {
-  real[] one_comp_mm_elim_abs(real t,
-                              real[] y,
-                              real[] theta,
-                              real[] x_r,
-                              int[] x_i) {
-    real dydt[1];
+  array[] real one_comp_mm_elim_abs(real t, array[] real y,
+                                    array[] real theta, array[] real x_r,
+                                    array[] int x_i) {
+    array[1] real dydt;
     real k_a = theta[1]; // Dosing rate in 1/day
     real K_m = theta[2]; // Michaelis-Menten constant in mg/L
     real V_m = theta[3]; // Maximum elimination rate in 1/day
@@ -12,64 +10,60 @@ functions {
     real V = x_r[2];
     real dose = 0;
     real elim = (V_m / V) * y[1] / (K_m + y[1]);
-
-    if (t > 0)
-      dose = exp(- k_a * t) * D * k_a / V;
-
+    
+    if (t > 0) 
+      dose = exp(-k_a * t) * D * k_a / V;
+    
     dydt[1] = dose - elim;
-
+    
     return dydt;
   }
 }
-
 data {
-  real t0;    // Initial time in days;
-  real C0[1]; // Initial concentration at t0 in mg/L
-
-  real D;   // Total dosage in mg
-  real V;   // Compartment volume in L
-
+  real t0; // Initial time in days;
+  array[1] real C0; // Initial concentration at t0 in mg/L
+  
+  real D; // Total dosage in mg
+  real V; // Compartment volume in L
+  
   int<lower=1> N_t;
-  real times[N_t];   // Measurement times in days
-
+  array[N_t] real times; // Measurement times in days
+  
   // Measured concentrations in effect compartment in mg/L
-  real C_hat[N_t];
+  array[N_t] real C_hat;
 }
-
 transformed data {
-  real x_r[2] = {D, V};
-  int x_i[0];
+  array[2] real x_r = {D, V};
+  array[0] int x_i;
 }
-
 parameters {
   real<lower=0> k_a; // Dosing rate in 1/day
   real<lower=0> K_m; // Michaelis-Menten constant in mg/L
   real<lower=0> V_m; // Maximum elimination rate in 1/day
   real<lower=0> sigma;
 }
-
 transformed parameters {
-  real C[N_t, 1];
+  array[N_t, 1] real C;
   {
-    real theta[3] = {k_a, K_m, V_m};
-    C = integrate_ode_bdf(one_comp_mm_elim_abs, C0, t0, times, theta, x_r, x_i);
+    array[3] real theta = {k_a, K_m, V_m};
+    C = integrate_ode_bdf(one_comp_mm_elim_abs, C0, t0, times, theta, x_r,
+                          x_i);
   }
 }
-
 model {
   // Priors
   k_a ~ cauchy(0, 1);
   K_m ~ cauchy(0, 1);
   V_m ~ cauchy(0, 1);
   sigma ~ cauchy(0, 1);
-
+  
   // Likelihood
-  for (n in 1:N_t)
+  for (n in 1 : N_t) 
     C_hat[n] ~ lognormal(log(C[n, 1]), sigma);
 }
-
 generated quantities {
-  real C_ppc[N_t];
-  for (n in 1:N_t)
+  array[N_t] real C_ppc;
+  for (n in 1 : N_t) 
     C_ppc[n] = lognormal_rng(log(C[n, 1]), sigma);
 }
+

--- a/benchmarks/pkpd/sim_one_comp_mm_elim_abs.stan
+++ b/benchmarks/pkpd/sim_one_comp_mm_elim_abs.stan
@@ -1,10 +1,8 @@
 functions {
-  real[] one_comp_mm_elim_abs(real t,
-                              real[] y,
-                              real[] theta,
-                              real[] x_r,
-                              int[] x_i) {
-    real dydt[1];
+  array[] real one_comp_mm_elim_abs(real t, array[] real y,
+                                    array[] real theta, array[] real x_r,
+                                    array[] int x_i) {
+    array[1] real dydt;
     real k_a = theta[1]; // Dosing rate in 1/day
     real K_m = theta[2]; // Michaelis-Menten constant in mg/L
     real V_m = theta[3]; // Maximum elimination rate in 1/day
@@ -12,51 +10,51 @@ functions {
     real V = x_r[2];
     real dose = 0;
     real elim = (V_m / V) * y[1] / (K_m + y[1]);
-
-    if (t > 0)
-      dose = exp(- k_a * t) * D * k_a / V;
-
+    
+    if (t > 0) 
+      dose = exp(-k_a * t) * D * k_a / V;
+    
     dydt[1] = dose - elim;
-
+    
     return dydt;
   }
 }
-
 transformed data {
   int N_t = 20;
-  real times[N_t];
+  array[N_t] real times;
   real t0 = 0;
-  real C0[1] = {0.0};
+  array[1] real C0 = {0.0};
   // Dosing rate in 1/day
   // Michaelis-Menten constant in mg/L
   // Maximum elimination rate in 1/day
-  real theta[3] = {0.75, 0.25, 1};
+  array[3] real theta = {0.75, 0.25, 1};
   real sigma = 0.1;
-  real x_r[2] = {30.0, 2.0}; // Total dosage in mg, Comparment volume in L
-  int x_i[0];
-
-  for (n in 1:N_t)
+  array[2] real x_r = {30.0, 2.0}; // Total dosage in mg, Comparment volume in L
+  array[0] int x_i;
+  
+  for (n in 1 : N_t) 
     times[n] = 0.5 * n;
 }
-
-model {}
-
+model {
+  
+}
 generated quantities {
   real t_init = t0;
-  real C_init[1] = {C0[1]};
-
+  array[1] real C_init = {C0[1]};
+  
   real D = x_r[1];
   real V = x_r[2];
-  real ts[N_t];
-
-  real C[N_t, 1];
-  real C_hat[N_t];
-
-  for (n in 1:N_t)
+  array[N_t] real ts;
+  
+  array[N_t, 1] real C;
+  array[N_t] real C_hat;
+  
+  for (n in 1 : N_t) 
     ts[n] = times[n];
-
+  
   C = integrate_ode_bdf(one_comp_mm_elim_abs, C0, t0, times, theta, x_r, x_i);
-
-  for (n in 1:N_t)
+  
+  for (n in 1 : N_t) 
     C_hat[n] = lognormal_rng(log(C[n, 1]), sigma);
 }
+

--- a/benchmarks/sir/sir.stan
+++ b/benchmarks/sir/sir.stan
@@ -2,70 +2,60 @@
 // http://www.ncbi.nlm.nih.gov/pmc/articles/PMC3380087/pdf/nihms372789.pdf
 
 functions {
-  
   // theta[1] = beta, water contact rate
   // theta[2] = kappa, C_{50}
   // theta[3] = gamma, recovery rate
   // theta[4] = xi, bacteria production rate
   // theta[5] = delta, bacteria removal rate
-  real[] simple_SIR(real t,
-                    real[] y,
-                    real[] theta,
-                    real[] x_r,
-                    int[] x_i) {
-
-    real dydt[4];
-
-    dydt[1] = - theta[1] * y[4] / (y[4] + theta[2]) * y[1];
+  array[] real simple_SIR(real t, array[] real y, array[] real theta,
+                          array[] real x_r, array[] int x_i) {
+    array[4] real dydt;
+    
+    dydt[1] = -theta[1] * y[4] / (y[4] + theta[2]) * y[1];
     dydt[2] = theta[1] * y[4] / (y[4] + theta[2]) * y[1] - theta[3] * y[2];
     dydt[3] = theta[3] * y[2];
     dydt[4] = theta[4] * y[2] - theta[5] * y[4];
-
+    
     return dydt;
   }
 }
-
 data {
   int<lower=0> N_t;
-  real t[N_t];
-  real y0[4];
-  int stoi_hat[N_t];
-  real B_hat[N_t];
+  array[N_t] real t;
+  array[4] real y0;
+  array[N_t] int stoi_hat;
+  array[N_t] real B_hat;
 }
-
 transformed data {
   real t0 = 0;
   real<lower=0> kappa = 1000000;
-
-  real x_r[0];
-  int x_i[0];
+  
+  array[0] real x_r;
+  array[0] int x_i;
 }
-
 parameters {
   real<lower=0> beta;
   real<lower=0> gamma;
   real<lower=0> xi;
   real<lower=0> delta;
 }
-
 transformed parameters {
-  real<lower=0> y[N_t, 4];
+  array[N_t, 4] real<lower=0> y;
   {
-    real theta[5] = {beta, kappa, gamma, xi, delta};
+    array[5] real theta = {beta, kappa, gamma, xi, delta};
     y = integrate_ode_rk45(simple_SIR, y0, t0, t, theta, x_r, x_i);
   }
 }
-  
 model {
   beta ~ cauchy(0, 2.5);
   gamma ~ cauchy(0, 1);
   xi ~ cauchy(0, 25);
   delta ~ cauchy(0, 1);
-
-  stoi_hat[1] ~ poisson(y0[1] - y[1, 1]);
-  for (n in 2:N_t)
-    stoi_hat[n] ~ poisson(y[n - 1, 1] - y[n, 1]);
-
-  B_hat ~ lognormal(log(col(to_matrix(y), 4)), 0.15);
   
+  stoi_hat[1] ~ poisson(y0[1] - y[1, 1]);
+  for (n in 2 : N_t) 
+    stoi_hat[n] ~ poisson(y[n - 1, 1] - y[n, 1]);
+  
+  B_hat ~ lognormal(log(col(to_matrix(y), 4)), 0.15);
 }
+


### PR DESCRIPTION
This is similar to https://github.com/stan-dev/stanc3/pull/1072 and https://github.com/stan-dev/example-models/pull/210. All it does is run `stanc --auto-format --canonicalize=deprecations` on the models which use outdated syntax or function names.